### PR TITLE
[Feat] 앨범 저장 취소 시 이미지 파일 삭제

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/background/workmanager/SynchronizationWorker.kt
+++ b/app/src/main/java/com/and04/naturealbum/background/workmanager/SynchronizationWorker.kt
@@ -268,8 +268,7 @@ class SynchronizationWorker @AssistedInject constructor(
 
         val valueList = fileNameToLabelUid.values.toList()
         val findAlbumData = valueList.find { value -> value.second == photo.fileName }
-        val uri = makeFileToUri(photo.uri, photo.fileName)
-
+        val uri = ImageConvert.makeFileToUri(photo.uri, photo.fileName, true)
 
         val labelId = findAlbumData?.first
             ?: fileNameToLabelUid[photo.label]?.first
@@ -381,32 +380,6 @@ class SynchronizationWorker @AssistedInject constructor(
             )
             if (result) syncDataStore.removeDeletedFileName(photo.fileName)
         }
-    }
-
-    private fun makeFileToUri(photoUri: String, fileName: String): String {
-        val context = applicationContext
-        val storage = context.filesDir
-        val imageFile = File(storage, fileName)
-        imageFile.createNewFile()
-
-        FileOutputStream(imageFile).use { fos ->
-            BitmapFactory.decodeStream(URL(photoUri).openStream()).apply {
-                if (Build.VERSION.SDK_INT >= 30) {
-                    compress(Bitmap.CompressFormat.WEBP_LOSSY, 100, fos)
-                } else {
-                    compress(Bitmap.CompressFormat.JPEG, 100, fos)
-                }
-
-                recycle()
-            }
-            fos.flush()
-        }
-
-        return FileProvider.getUriForFile(
-            context,
-            "${context.packageName}.fileprovider",
-            imageFile
-        ).toString()
     }
 
     private fun isUnSyncLabel(label: SyncAlbumsDto, firebaseLabel: FirebaseLabelResponse): Boolean {

--- a/app/src/main/java/com/and04/naturealbum/ui/add/savephoto/SavePhotoScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/add/savephoto/SavePhotoScreen.kt
@@ -5,8 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.location.Location
 import android.net.Uri
 import androidx.activity.compose.BackHandler
@@ -80,7 +78,6 @@ import com.and04.naturealbum.utils.network.NetworkState
 import com.and04.naturealbum.utils.network.NetworkState.DISCONNECTED
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
-import java.io.IOException
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -89,7 +86,6 @@ fun SavePhotoScreen(
     locationHandler: LocationHandler,
     location: Location?,
     model: Uri,
-    fileName: String,
     onBack: () -> Unit,
     onSave: () -> Unit,
     onCancel: () -> Unit,
@@ -141,7 +137,6 @@ fun SavePhotoScreen(
 
     SavePhotoScreen(
         model = model,
-        fileName = fileName,
         location = newLocation,
         photoSaveState = photoSaveState,
         rememberDescription = rememberDescription,
@@ -165,7 +160,6 @@ fun SavePhotoScreen(
 @Composable
 fun SavePhotoScreen(
     model: Uri,
-    fileName: String,
     location: State<Location?>,
     rememberDescription: State<String>,
     onDescriptionChange: (String) -> Unit,
@@ -200,8 +194,7 @@ fun SavePhotoScreen(
             if (context.isPortrait()) {
                 SavePhotoScreenPortrait(
                     innerPadding = innerPadding,
-                    model = model,
-                    fileName = fileName,
+                    uri = model,
                     label = label,
                     location = location.value!!,
                     rememberDescription = rememberDescription,
@@ -216,8 +209,7 @@ fun SavePhotoScreen(
             } else {
                 SavePhotoScreenLandscape(
                     innerPadding = innerPadding,
-                    model = model,
-                    fileName = fileName,
+                    uri = model,
                     label = label,
                     location = location.value!!,
                     rememberDescription = rememberDescription,
@@ -381,19 +373,9 @@ fun Description(
     }
 }
 
-private fun loadImageFromUri(context: Context, uri: Uri): Bitmap? {
-    return try {
-        context.contentResolver.openInputStream(uri)?.use { inputStream ->
-            BitmapFactory.decodeStream(inputStream)
-        }
-    } catch (e: IOException) {
-        null
-    }
-}
-
 fun insertFirebaseService(
     context: Context,
-    model: Uri,
+    uri: String,
     fileName: String,
     label: Label,
     location: Location,
@@ -403,7 +385,7 @@ fun insertFirebaseService(
     if (Firebase.auth.currentUser == null || NetworkState.getNetWorkCode() == DISCONNECTED) return
     val newTime = time.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
     val intent = Intent(context, FirebaseInsertService::class.java).apply {
-        putExtra(SERVICE_URI, model.toString())
+        putExtra(SERVICE_URI, uri)
         putExtra(SERVICE_FILENAME, fileName)
         putExtra(SERVICE_LABEL, label)
         putExtra(SERVICE_LOCATION_LATITUDE, location.latitude)
@@ -428,7 +410,6 @@ private fun ScreenPreview() {
         SavePhotoScreen(
             model = "".toUri(),
             location = location,
-            fileName = "fileName.jpg",
             rememberDescription = rememberDescription,
             onDescriptionChange = { },
             isRepresented = isRepresented,

--- a/app/src/main/java/com/and04/naturealbum/ui/add/savephoto/SavePhotoScreenLandscape.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/add/savephoto/SavePhotoScreenLandscape.kt
@@ -26,14 +26,14 @@ import coil3.request.crossfade
 import com.and04.naturealbum.R
 import com.and04.naturealbum.data.localdata.room.Label
 import com.and04.naturealbum.ui.utils.UiState
+import com.and04.naturealbum.utils.image.ImageConvert
 import java.time.LocalDateTime
 import java.time.ZoneId
 
 @Composable
 fun SavePhotoScreenLandscape(
     innerPadding: PaddingValues,
-    model: Uri,
-    fileName: String,
+    uri: Uri,
     label: Label?,
     location: Location,
     rememberDescription: State<String>,
@@ -55,7 +55,7 @@ fun SavePhotoScreenLandscape(
         ) {
             AsyncImage(
                 model = ImageRequest.Builder(context)
-                    .data(model)
+                    .data(uri)
                     .crossfade(true)
                     .build(),
                 contentDescription = stringResource(R.string.save_photo_screen_image_description),
@@ -108,8 +108,10 @@ fun SavePhotoScreenLandscape(
                     stringRes = R.string.save_photo_screen_save,
                     onClick = {
                         val time = LocalDateTime.now(ZoneId.of("UTC"))
+                        val fileName = "${System.currentTimeMillis()}.jpg"
+                        val fileUri = ImageConvert.makeFileToUri(uri.toString(), fileName)
                         savePhoto(
-                            model.toString(),
+                            fileUri,
                             fileName,
                             label!!,
                             location,
@@ -120,7 +122,7 @@ fun SavePhotoScreenLandscape(
 
                         insertFirebaseService(
                             context = context,
-                            model = model,
+                            uri = fileUri,
                             fileName = fileName,
                             label = label,
                             location = location,

--- a/app/src/main/java/com/and04/naturealbum/ui/add/savephoto/SavePhotoScreenPortrait.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/add/savephoto/SavePhotoScreenPortrait.kt
@@ -26,14 +26,14 @@ import coil3.request.crossfade
 import com.and04.naturealbum.R
 import com.and04.naturealbum.data.localdata.room.Label
 import com.and04.naturealbum.ui.utils.UiState
+import com.and04.naturealbum.utils.image.ImageConvert
 import java.time.LocalDateTime
 import java.time.ZoneId
 
 @Composable
 fun SavePhotoScreenPortrait(
     innerPadding: PaddingValues,
-    model: Uri,
-    fileName: String,
+    uri: Uri,
     label: Label?,
     location: Location,
     rememberDescription: State<String>,
@@ -51,7 +51,7 @@ fun SavePhotoScreenPortrait(
     ) {
         AsyncImage(
             model = ImageRequest.Builder(context)
-                .data(model)
+                .data(uri)
                 .crossfade(true)
                 .build(),
             contentDescription = stringResource(R.string.save_photo_screen_image_description),
@@ -98,8 +98,10 @@ fun SavePhotoScreenPortrait(
                 stringRes = R.string.save_photo_screen_save,
                 onClick = {
                     val time = LocalDateTime.now(ZoneId.of("UTC"))
+                    val fileName = "${System.currentTimeMillis()}.jpg"
+                    val fileUri = ImageConvert.makeFileToUri(uri.toString(), fileName)
                     savePhoto(
-                        model.toString(),
+                        fileUri,
                         fileName,
                         label!!,
                         location,
@@ -110,7 +112,7 @@ fun SavePhotoScreenPortrait(
 
                     insertFirebaseService(
                         context = context,
-                        model = model,
+                        uri = fileUri,
                         fileName = fileName,
                         label = label,
                         location = location,

--- a/app/src/main/java/com/and04/naturealbum/ui/add/savephoto/navigation/SaveAlbumNavigation.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/add/savephoto/navigation/SaveAlbumNavigation.kt
@@ -26,7 +26,10 @@ fun NavGraphBuilder.saveAlbumNavGraph(
             location = state.lastLocation.value,
             model = state.imageUri.value,
             fileName = state.fileName.value,
-            onBack = { state.takePicture(takePictureLauncher) },
+            onBack = {
+                state.deleteFilePhoto()
+                state.takePicture(takePictureLauncher)
+             },
             onSave = {
                 navigator.navigateSavePhotoToAlbum()
                 state.selectedLabel.value = null

--- a/app/src/main/java/com/and04/naturealbum/ui/add/savephoto/navigation/SaveAlbumNavigation.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/add/savephoto/navigation/SaveAlbumNavigation.kt
@@ -25,14 +25,14 @@ fun NavGraphBuilder.saveAlbumNavGraph(
             locationHandler = state.locationHandler.value,
             location = state.lastLocation.value,
             model = state.imageUri.value,
-            fileName = state.fileName.value,
             onBack = {
-                state.deleteFilePhoto()
+                state.deleteCachePhoto()
                 state.takePicture(takePictureLauncher)
-             },
+            },
             onSave = {
                 navigator.navigateSavePhotoToAlbum()
                 state.selectedLabel.value = null
+                state.deleteCachePhoto()
             },
             onCancel = { navigator.navigateToHome() },
             label = state.selectedLabel.value,

--- a/app/src/main/java/com/and04/naturealbum/ui/navigation/NatureAlbumState.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/navigation/NatureAlbumState.kt
@@ -30,9 +30,8 @@ class NatureAlbumState(
     var lastLocation = mutableStateOf<Location?>(null)
     var locationHandler = mutableStateOf(LocationHandler(context))
     var imageUri = mutableStateOf(Uri.EMPTY)
-    var fileName = mutableStateOf("")
     var selectedLabel = mutableStateOf<Label?>(null)
-    private var imageFile = mutableStateOf<File?>(null)
+    private var imageCache = mutableStateOf<File?>(null)
     var currentUid = mutableStateOf("")
 
     fun handleLauncher(
@@ -40,13 +39,11 @@ class NatureAlbumState(
         navigator: NatureAlbumNavigator
     ) {
         if (result.resultCode == RESULT_OK) {
-            val resizePicture = ImageConvert.resizeImage(imageUri.value) { file ->
-                imageFile.value?.delete()
-                imageFile.value = file
-            }!!
-
-            imageUri.value = resizePicture.uri
-            fileName.value = resizePicture.fileName
+            ImageConvert.resizeImage(imageUri.value) { file, uri ->
+                imageCache.value?.delete()
+                imageCache.value = file
+                imageUri.value = uri
+            }
 
             locationHandler.value.getLocation { location -> lastLocation.value = location }
 
@@ -59,13 +56,13 @@ class NatureAlbumState(
     }
 
     fun takePicture(launcher: ManagedActivityResultLauncher<Intent, ActivityResult>) {
-        fileName.value = "temp_${System.currentTimeMillis()}.jpg"
-        imageFile.value = File(context.filesDir, fileName.value)
+        val fileName = "temp_${System.currentTimeMillis()}"
+        imageCache.value = File.createTempFile(fileName, ".jpg", context.cacheDir)
         imageUri.value =
             FileProvider.getUriForFile(
                 context,
                 "${context.packageName}.fileprovider",
-                imageFile.value!!
+                imageCache.value!!
             )
 
         Intent(MediaStore.ACTION_IMAGE_CAPTURE).apply {
@@ -78,8 +75,8 @@ class NatureAlbumState(
         }
     }
 
-    fun deleteFilePhoto() {
-        imageFile.value?.delete()
+    fun deleteCachePhoto() {
+        imageCache.value?.delete()
     }
 }
 
@@ -91,7 +88,6 @@ fun rememberNatureAlbumState(
         save = { state ->
             mapOf(
                 "imageUri" to state.imageUri.value.toString(),
-                "fileName" to state.fileName.value,
                 "lastLocation" to state.lastLocation.value,
             )
         },
@@ -100,7 +96,6 @@ fun rememberNatureAlbumState(
                 context = context,
             ).apply {
                 imageUri.value = Uri.parse(restoredMap["imageUri"] as String)
-                fileName.value = restoredMap["fileName"] as String
                 lastLocation.value = restoredMap["lastLocation"] as Location?
             }
         }

--- a/app/src/main/java/com/and04/naturealbum/ui/navigation/NatureAlbumState.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/navigation/NatureAlbumState.kt
@@ -40,8 +40,11 @@ class NatureAlbumState(
         navigator: NatureAlbumNavigator
     ) {
         if (result.resultCode == RESULT_OK) {
-            val resizePicture = ImageConvert.resizeImage(imageUri.value)!!
-            imageFile.value?.delete()
+            val resizePicture = ImageConvert.resizeImage(imageUri.value) { file ->
+                imageFile.value?.delete()
+                imageFile.value = file
+            }!!
+
             imageUri.value = resizePicture.uri
             fileName.value = resizePicture.fileName
 
@@ -74,6 +77,10 @@ class NatureAlbumState(
                 // TODO: 카메라 전환 오류 처리
             }
         }
+    }
+
+    fun deleteFilePhoto() {
+        imageFile.value?.delete()
     }
 }
 

--- a/app/src/main/java/com/and04/naturealbum/ui/navigation/NatureAlbumState.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/navigation/NatureAlbumState.kt
@@ -59,7 +59,6 @@ class NatureAlbumState(
     }
 
     fun takePicture(launcher: ManagedActivityResultLauncher<Intent, ActivityResult>) {
-        // TODO: imageUri가 EMPTY가 아닐때 해당 파일 삭제
         fileName.value = "temp_${System.currentTimeMillis()}.jpg"
         imageFile.value = File(context.filesDir, fileName.value)
         imageUri.value =

--- a/app/src/main/java/com/and04/naturealbum/utils/image/ImageConvert.kt
+++ b/app/src/main/java/com/and04/naturealbum/utils/image/ImageConvert.kt
@@ -31,30 +31,22 @@ object ImageConvert {
         imageFile.createNewFile()
 
         FileOutputStream(imageFile).use { fos ->
-            if (external) {
-                BitmapFactory.decodeStream(URL(photoUri).openStream()).apply {
-                    if (Build.VERSION.SDK_INT >= 30) {
-                        compress(Bitmap.CompressFormat.WEBP_LOSSY, COMPRESS_QUALITY, fos)
-                    } else {
-                        compress(Bitmap.CompressFormat.JPEG, COMPRESS_QUALITY, fos)
-                    }
-
-                    recycle()
+            BitmapFactory.decodeStream(
+                if (external) {
+                    URL(photoUri).openStream()
+                } else {
+                    BufferedInputStream(
+                        context.contentResolver.openInputStream(photoUri.toUri())
+                    )
                 }
-            } else {
-                val bufferedInputStream = BufferedInputStream(
-                    context.contentResolver.openInputStream(photoUri.toUri())
-                )
+            ).apply {
+                if (Build.VERSION.SDK_INT >= 30) {
+                    compress(Bitmap.CompressFormat.WEBP_LOSSY, COMPRESS_QUALITY, fos)
+                } else {
+                    compress(Bitmap.CompressFormat.JPEG, COMPRESS_QUALITY, fos)
+                }
 
-                BitmapFactory.decodeStream(bufferedInputStream).apply {
-                    if (Build.VERSION.SDK_INT >= 30) {
-                        compress(Bitmap.CompressFormat.WEBP_LOSSY, COMPRESS_QUALITY, fos)
-                    } else {
-                        compress(Bitmap.CompressFormat.JPEG, COMPRESS_QUALITY, fos)
-                    }
-
-                    recycle()
-                } ?: throw NullPointerException()
+                recycle()
             }
 
             fos.flush()

--- a/app/src/main/java/com/and04/naturealbum/utils/image/ImageConvert.kt
+++ b/app/src/main/java/com/and04/naturealbum/utils/image/ImageConvert.kt
@@ -22,7 +22,10 @@ object ImageConvert {
     private const val COMPRESS_QUALITY = 80
     private const val IN_SAMPLE_SIZE = 16
 
-    fun resizeImage(uri: Uri): ResizePicture? {
+    fun resizeImage(
+        uri: Uri,
+        changeFile: (File) -> Unit,
+    ): ResizePicture? {
         try {
             val context = NatureAlbum.getInstance()
             val storage = context.filesDir
@@ -44,6 +47,8 @@ object ImageConvert {
 
                 fos.flush()
             }
+
+            changeFile(imageFile)
 
             return ResizePicture(
                 fileName = fileName,

--- a/app/src/main/java/com/and04/naturealbum/utils/image/ImageConvert.kt
+++ b/app/src/main/java/com/and04/naturealbum/utils/image/ImageConvert.kt
@@ -9,12 +9,14 @@ import android.os.Build
 import android.util.Base64
 import android.util.Log
 import androidx.core.content.FileProvider
+import androidx.core.net.toUri
 import androidx.exifinterface.media.ExifInterface
 import com.and04.naturealbum.NatureAlbum
 import java.io.BufferedInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
+import java.net.URL
 
 object ImageConvert {
     private const val MAX_WIDTH = 800
@@ -22,17 +24,58 @@ object ImageConvert {
     private const val COMPRESS_QUALITY = 80
     private const val IN_SAMPLE_SIZE = 16
 
+    fun makeFileToUri(photoUri: String, fileName: String, external: Boolean = false): String {
+        val context = NatureAlbum.getInstance()
+        val storage = context.filesDir
+        val imageFile = File(storage, fileName)
+        imageFile.createNewFile()
+
+        FileOutputStream(imageFile).use { fos ->
+            if (external) {
+                BitmapFactory.decodeStream(URL(photoUri).openStream()).apply {
+                    if (Build.VERSION.SDK_INT >= 30) {
+                        compress(Bitmap.CompressFormat.WEBP_LOSSY, COMPRESS_QUALITY, fos)
+                    } else {
+                        compress(Bitmap.CompressFormat.JPEG, COMPRESS_QUALITY, fos)
+                    }
+
+                    recycle()
+                }
+            } else {
+                val bufferedInputStream = BufferedInputStream(
+                    context.contentResolver.openInputStream(photoUri.toUri())
+                )
+
+                BitmapFactory.decodeStream(bufferedInputStream).apply {
+                    if (Build.VERSION.SDK_INT >= 30) {
+                        compress(Bitmap.CompressFormat.WEBP_LOSSY, COMPRESS_QUALITY, fos)
+                    } else {
+                        compress(Bitmap.CompressFormat.JPEG, COMPRESS_QUALITY, fos)
+                    }
+
+                    recycle()
+                } ?: throw NullPointerException()
+            }
+
+            fos.flush()
+        }
+
+        return FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            imageFile
+        ).toString()
+    }
+
     fun resizeImage(
         uri: Uri,
-        changeFile: (File) -> Unit,
-    ): ResizePicture? {
+        changeFile: (File, Uri) -> Unit,
+    ) {
         try {
             val context = NatureAlbum.getInstance()
-            val storage = context.filesDir
-            val fileName = "${System.currentTimeMillis()}.jpg"
-
-            val imageFile = File(storage, fileName)
-            imageFile.createNewFile()
+            val storage = context.cacheDir
+            val fileName = "${System.currentTimeMillis()}"
+            val imageFile = File.createTempFile(fileName, ".jpg", storage)
 
             FileOutputStream(imageFile).use { fos ->
                 decodeBitmapFromUri(context = context, uri = uri)?.apply {
@@ -48,22 +91,17 @@ object ImageConvert {
                 fos.flush()
             }
 
-            changeFile(imageFile)
-
-            return ResizePicture(
-                fileName = fileName,
-                uri = FileProvider.getUriForFile(
+            changeFile(
+                imageFile,
+                FileProvider.getUriForFile(
                     context,
                     "${context.packageName}.fileprovider",
                     imageFile
                 )
             )
-
         } catch (e: Exception) {
             Log.e("ImageConvert", "FileUtil - ${e.message}")
         }
-
-        return null
     }
 
     private fun decodeBitmapFromUri(context: Context, uri: Uri): Bitmap? {
@@ -158,8 +196,3 @@ object ImageConvert {
         }
     }
 }
-
-data class ResizePicture(
-    val fileName: String,
-    val uri: Uri,
-)

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -3,4 +3,8 @@
     <files-path
         name="internal_files"
         path="." />
+
+    <cache-path
+        name="temp_images"
+        path="." />
 </paths>

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.experimental.androidTest.useUnifiedTestPlatform=false
+#android.experimental.androidTest.useUnifiedTestPlatform=false


### PR DESCRIPTION
카메라 촬영 직후 이미지는 캐시로 저장 후 저장 시 파일로 변경
- 강제 종료 시 파일로 남아있으면 불필요한 용량 차지
- 디스크 캐시로 저장하여 추후에 임시 저장 기능도 고려 가능
- 뒤로가기 또는 취소 시 캐시 삭제

