### PR TITLE
선형 탐색과 이진 탐색 속도 비교 테스트 진행 및 수정

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/background/workmanager/SynchronizationWorker.kt
+++ b/app/src/main/java/com/and04/naturealbum/background/workmanager/SynchronizationWorker.kt
@@ -145,7 +145,7 @@ class SynchronizationWorker @AssistedInject constructor(
 
             val label = async {
                 val labels = albumRepository.getLabelsToList(uid).getOrThrow()
-                val allLocalLabels = syncRepository.getSyncCheckAlbums()
+                val allLocalLabels = syncRepository.getSyncCheckAlbums().sortedBy { it.labelName }
 
                 allLocalLabels.forEach { localLabel ->
                     var duplicationLabel = false
@@ -173,7 +173,7 @@ class SynchronizationWorker @AssistedInject constructor(
 
                 labels.forEach { firebaseLabel ->
                     if (
-                        !allLocalLabels.sortedBy { it.labelName }.binarySearch(target = firebaseLabel.labelName)
+                        !allLocalLabels.binarySearch(target = firebaseLabel.labelName)
                     ) {
                         val labelId = syncRepository.getIdByName(firebaseLabel.labelName)
                         if (labelId == null) {
@@ -188,11 +188,11 @@ class SynchronizationWorker @AssistedInject constructor(
 
             val photoDetail = async {
                 val allServerPhotos = albumRepository.getPhotosToList(uid).getOrThrow()
-                val allLocalPhotos = syncRepository.getSyncCheckPhotos()
+                val allLocalPhotos = syncRepository.getSyncCheckPhotos().sortedBy { it.fileName }
 
                 allLocalPhotos.forEach { photo ->
                     if (
-                        !allServerPhotos.sortedBy { it.fileName }.binarySearch(target = photo.fileName)
+                        !allServerPhotos.binarySearch(target = photo.fileName)
                     ) {
                         launch {
                             insertPhotoDetailToServer(uid, photo)
@@ -202,7 +202,7 @@ class SynchronizationWorker @AssistedInject constructor(
 
                 unSynchronizedPhotoDetailsToLocal.addAll(
                     allServerPhotos.filter { photo ->
-                        !allLocalPhotos.sortedBy { it.fileName }.binarySearch(target = photo.fileName)
+                        !allLocalPhotos.binarySearch(target = photo.fileName)
                     }
                 )
             }

--- a/app/src/test/java/com/and04/naturealbum/sync/BinarySearchTest.kt
+++ b/app/src/test/java/com/and04/naturealbum/sync/BinarySearchTest.kt
@@ -1,0 +1,93 @@
+package com.and04.naturealbum.sync
+
+import com.and04.naturealbum.background.workmanager.binarySearch
+import com.and04.naturealbum.data.dto.FirebaseLabelResponse
+import com.and04.naturealbum.data.dto.SyncAlbumsDto
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.system.measureTimeMillis
+
+class BinarySearchTest {
+
+    @Test
+    fun 선형탐색과_이진탐색_속도_측정() {
+        val countArr = arrayOf(1000, 10000, 50000)
+
+        countArr.forEach {
+            val local = getSyncAlbumDtoDummyData(it)
+            val firebase = getFirebaseLabelResponseDummyData(it)
+
+            val linearSearchTime = checkLinearSearchTime(firebase, local)
+            val binarySearchTime = checkBinarySearchTime(firebase, local)
+
+            println("Count: $it")
+            println("LinearSearch: $linearSearchTime")
+            println("BinarySearch: $binarySearchTime")
+
+            assertTrue(linearSearchTime > binarySearchTime)
+        }
+    }
+
+    private fun checkLinearSearchTime(
+        firebase: List<FirebaseLabelResponse>,
+        local: List<SyncAlbumsDto>
+    ): Long = measureTimeMillis {
+        firebase.forEach { f ->
+            for (data in local) {
+                if (data.labelName == f.labelName) break
+            }
+        }
+    }
+
+    private fun checkBinarySearchTime(
+        firebase: List<FirebaseLabelResponse>,
+        local: List<SyncAlbumsDto>
+    ): Long = measureTimeMillis {
+        val sortedLocal = local.sortedBy { it.labelName }
+
+        firebase.forEach { f ->
+            sortedLocal.binarySearch(target = f.labelName)
+        }
+    }
+
+    private fun getSyncAlbumDtoDummyData(count: Int): List<SyncAlbumsDto> {
+        val dummyList = mutableListOf<SyncAlbumsDto>()
+
+        repeat(count) {
+            dummyList.add(
+                SyncAlbumsDto(
+                    labelId = 0,
+                    labelName = getRandomString(),
+                    labelBackgroundColor = "",
+                    photoDetailUri = "",
+                    fileName = ""
+                )
+            )
+        }
+
+        return dummyList
+    }
+
+    private fun getFirebaseLabelResponseDummyData(count: Int): List<FirebaseLabelResponse> {
+        val dummyList = mutableListOf<FirebaseLabelResponse>()
+
+        repeat(count) {
+            dummyList.add(
+                FirebaseLabelResponse(
+                    labelName = getRandomString(),
+                    backgroundColor = "",
+                    thumbnailUri = "",
+                    fileName = ""
+                )
+            )
+        }
+        return dummyList
+    }
+
+    private fun getRandomString(): String {
+        val charset = ('a'..'z') + ('0'..'9')
+        return (0..(3..10).random())
+            .map { charset.random() }
+            .joinToString("")
+    }
+}


### PR DESCRIPTION
1,000개, 10,000개, 50,000개의 테스트 데이터로 속도 측정
 
![image](https://github.com/user-attachments/assets/69f99822-bcf1-42b6-9689-19c9cda9c82a)   

1,000개의 경우
- 선형: 0.021초
- 이진: 0.014초

10,000개의 경우
- 선형: 0.671초
- 이진: 0.011초

50,000개의 경우
- 선형: 39.844초
- 이진: 0.107초
------
테스트마다 결과는 다르지만 대용량 데이터 기준 확연한 차이를 보여주었다.
다만 800개 미만 데이터의 경우 비슷하거나 선형 탐색이 미세하게 빠르다.